### PR TITLE
Add elapsed to FRAME_UPDATE

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1433,9 +1433,9 @@ do
       update_frame = CreateFrame("FRAME");
     end
     if not(updating) then
-      update_frame:SetScript("OnUpdate", function()
+      update_frame:SetScript("OnUpdate", function(self, elapsed)
         if not(WeakAuras.IsPaused()) then
-          WeakAuras.ScanEvents("FRAME_UPDATE");
+          WeakAuras.ScanEvents("FRAME_UPDATE", elapsed);
         end
       end);
       updating = true;


### PR DESCRIPTION
### This is an exact copy of a [change made in the official WeakAuras repository](https://github.com/WeakAuras/WeakAuras2/pull/3750).

Allows triggers using the `FRAME_UPDATE` event to access the `elapsed` value from [OnUpdate](https://wowpedia.fandom.com/wiki/UIHANDLER_OnUpdate). It makes both throttling and making framerate-independent animations much simpler.